### PR TITLE
Sets search input font-size to 16px to prevent iOS zooming

### DIFF
--- a/dest/index.css
+++ b/dest/index.css
@@ -53,6 +53,7 @@ html:not(.compact) .pokedata {
 	width: max(50%,200px);
 	margin: 10px;
 	border-radius: 5px;
+	font-size: 16px;
 }
 .search .results {
 	display: flex;


### PR DESCRIPTION
Resolves https://github.com/Hidden50/pq/issues/8

https://user-images.githubusercontent.com/4706195/145124682-28a14ccb-d2e8-4bfa-b6fb-35fb9304c236.mp4


